### PR TITLE
Allow for passing the sns arn output to a lambda

### DIFF
--- a/modules/cwe_lambda/output.tf
+++ b/modules/cwe_lambda/output.tf
@@ -1,0 +1,4 @@
+output "arn" {
+  description = "SNS Topic ARN"
+  value       = module.sns_forwarder.arn
+}


### PR DESCRIPTION
Need to get to the sns arn output from the child module. Adding in reference to this output in order to expose the sns arn to a lambda function.