### PR TITLE
Patch: Revert "Allow optional use of CWEs with sqs_queue lambdas"

### DIFF
--- a/modules/sqs_lambda/main.tf
+++ b/modules/sqs_lambda/main.tf
@@ -17,7 +17,6 @@ module "sqs_queue" {
 }
 
 resource "aws_cloudwatch_event_target" "cwe_rule_target" {
-  count     = var.cloudwatch_event_rule_id != null ? 1 : 0
   rule      = var.cloudwatch_event_rule_id
   target_id = var.target_id
   arn       = module.sqs_queue.arn

--- a/modules/sqs_lambda/modules/sqs_queue_policy/main.tf
+++ b/modules/sqs_lambda/modules/sqs_queue_policy/main.tf
@@ -3,8 +3,7 @@
 */
 data "aws_caller_identity" "current" {}
 
-resource "aws_sqs_queue_policy" "cwe_queue_policy" {
-  count     = var.cwe_id != null ? 1 : 0
+resource "aws_sqs_queue_policy" "queue_policy" {
   queue_url = var.sqs_queue_id
 
   policy = <<POLICY
@@ -40,28 +39,6 @@ resource "aws_sqs_queue_policy" "cwe_queue_policy" {
 POLICY
 }
 
-resource "aws_sqs_queue_policy" "no_cwe_queue_policy" {
-  count     = var.cwe_id == null ? 1 : 0
-  queue_url = var.sqs_queue_id
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Id": "sqspolicy",
-  "Statement": [
-    {
-      "Sid": "AllowSNSTopic",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "sns.amazonaws.com"
-      },
-      "Action": "sqs:SendMessage",
-      "Resource": "${var.sqs_queue_arn}"
-    }
-  ]
-}
-POLICY
-}
 
 data "aws_iam_policy_document" "sqs_queue_policy" {
   statement {

--- a/modules/sqs_lambda/variables.tf
+++ b/modules/sqs_lambda/variables.tf
@@ -1,13 +1,11 @@
 variable "cloudwatch_event_rule_id" {
   description = "Cloudwatch event rule name"
   type        = string
-  default     = null
 }
 
 variable "cloudwatch_event_rule_arn" {
   description = "Arn of previously generated event rule"
   type        = string
-  default     = null
 }
 
 variable "target_id" {


### PR DESCRIPTION
Reverts reflexivesecurity/reflex-engine#103